### PR TITLE
feat: export parser meta

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
+import {
+  name as packageName,
+  version as packageVersion,
+} from "../package.json";
+
 export const parseForESLint = (code: string) => ({
   ast: {
     type: "Program",
@@ -13,3 +18,8 @@ export const parseForESLint = (code: string) => ({
     Program: [],
   },
 });
+
+export const meta = {
+  name: packageName,
+  version: packageVersion,
+};


### PR DESCRIPTION
I tried to run `eslint --print-config` and it threw the following:
```shell
❯ pnpm eslint --print-config package.json

Oops! Something went wrong! :(

ESLint: 8.56.0

Error: Could not serialize parser object (missing 'meta' object).
    at Object.value (/new-eslint-config/node_modules/.pnpm/eslint@8.56.0/node_modules/eslint/lib/config/flat-config-array.js:239:27)
    at JSON.stringify (<anonymous>)
    at Object.execute (/new-eslint-config/node_modules/.pnpm/eslint@8.56.0/node_modules/eslint/lib/cli.js:384:27)
    at async main (/new-eslint-config/node_modules/.pnpm/eslint@8.56.0/node_modules/eslint/bin/eslint.js:152:22)
```

I guess it would be nice to export meta, as ESLint suggests :)
https://eslint.org/docs/latest/extend/custom-parsers#meta-data-in-custom-parsers